### PR TITLE
(feature) add SpamTitan

### DIFF
--- a/integrations/SpamTitan/PSCreateAccountsFromVendor.ps1
+++ b/integrations/SpamTitan/PSCreateAccountsFromVendor.ps1
@@ -1,0 +1,7 @@
+Function Invoke-SyncAccounts {
+    Param() Process {
+        $usage = Get-SpamTitanDetails
+        return Invoke-CreateAccounts $usage
+    }
+}
+

--- a/integrations/SpamTitan/PSCreateServicesFromVendor.ps1
+++ b/integrations/SpamTitan/PSCreateServicesFromVendor.ps1
@@ -1,0 +1,7 @@
+ Function Invoke-SyncServices {
+    Param(
+    ) Process {
+        $RequiredServices = GetVendorServices
+        return Invoke-CreateServices $RequiredServices "https://meetgradient.com" "phil.flamingo@meetgradient.com"
+    }
+}

--- a/integrations/SpamTitan/PSCustomIntegrations.ps1
+++ b/integrations/SpamTitan/PSCustomIntegrations.ps1
@@ -1,0 +1,98 @@
+# To create a new SpamTitan API token, you will need to follow these steps, or run New-SpamTitanToken
+
+#Log in to your SpamTitan account.
+#Go to the API Tokens section in the SpamTitan console.
+#Click on the "Create" button to create a new token.
+#Enter a name for your token in the "Token Name" field.
+#Select the appropriate permissions for the token in the "Permissions" section.
+#Click on the "Create" button to generate a new API token.
+#Save the token somewhere secure, as you will not be able to view it again.
+#Once you have created the token, you can use it to authenticate with the SpamTitan API and access the available endpoints. Please refer to the SpamTitan API documentation for further information on how to use the API with your newly created token.
+
+function New-SpamTitanToken {
+    param (
+    )
+
+    # Build the request body
+    $body = @{
+        email = $Env:USER
+        password = $Env:USER_PASSWORD
+    } | ConvertTo-Json
+
+    # Send the API request to create the token
+    $response = Invoke-RestMethod -Method Post -Uri "$($Env:BASE_URL)/auth/tokens" -Body $body
+
+    # Get the new token value
+    $newToken = $response.access_token
+
+    # Output the new token
+    Write-Output $newToken
+}
+
+function Set-SpamTitanHeaders {
+    param ()
+
+    $headers = @{
+        'Authorization' = "Bearer $($Env:API_TOKEN)";
+        'Accept' = 'application/json';
+        'Content-Type' = 'application/json';
+    }
+
+    Write-Host $headers
+
+    return $headers
+}
+
+function Get-SpamTitanDetails {
+    param (
+        [int]$DaysBack = 30
+    )
+
+    # Set headers
+    $headers = Set-SpamTitanHeaders
+
+    # Initialize hashtable
+    $usage = @{}
+
+    # Calculate date range
+    $end_date = (Get-Date).AddDays(0).ToString("yyyy-MM-dd")
+    $start_date = (Get-Date).AddDays(-$DaysBack).ToString("yyyy-MM-dd")
+
+    # Retrieve domain groups
+    $url = "$($Env:BASE_URL)/domain-groups"
+    $groups_response = Invoke-RestMethod -Uri $url -Headers $headers -Method Get
+    $groups = $groups_response.data
+
+    if ($groups.Count -eq 0) {
+        Write-Output "No domain groups found"
+    } else {
+        foreach ($group in $groups) {
+            $group_id = $group.id
+            $group_name = $group.name
+
+            # Retrieve license usage for domain group and date range
+            $url = "$($Env:BASE_URL)/reports/license-usage?start_date=$start_date&end_date=$end_date&domain_group_id=$($group_id.ToString())"
+            $usage_response = Invoke-RestMethod -Uri $url -Headers $headers -Method Get
+            $maximum = $usage_response.data.maximum
+
+            # Add usage data to hashtable
+            $data = @{
+                "id" = $group_id
+                "name" = $group_name
+                "maximum" = $maximum
+            }
+            $usage[$group_id] = $data
+        }
+    }
+
+    return $usage
+}
+
+Function GetVendorServices {
+    Process {
+        $propertiesToCreateServices = @(
+        @{ Name = "Total Licenses"; Description = "Email Anti Spam & Security"; Category = "security"; Subcategory = "email security" }
+   )
+        return $propertiesToCreateServices
+    }
+}

--- a/integrations/SpamTitan/PSImports.psm1
+++ b/integrations/SpamTitan/PSImports.psm1
@@ -1,0 +1,16 @@
+$ScriptDir = Split-Path $script:MyInvocation.MyCommand.Path
+#
+Import-Module -Name "${ScriptDir}\..\..\PSGradient"
+. "${ScriptDir}\PSInit.ps1"
+. "${ScriptDir}\PSCreateAccountsFromVendor.ps1"
+. "${ScriptDir}\PSCreateServicesFromVendor.ps1"
+. "${ScriptDir}\PSSyncUsage.ps1"
+. "${ScriptDir}\PSCustomIntegrations.ps1"
+. "${ScriptDir}\..\..\PSGradient\GradientHelpers\PSAuthenticate.ps1"
+. "${ScriptDir}\..\..\PSGradient\GradientHelpers\PSCreateAccounts.ps1"
+. "${ScriptDir}\..\..\PSGradient\GradientHelpers\PSCreateServices.ps1"
+. "${ScriptDir}\..\..\PSGradient\GradientHelpers\PSUpdateIntegrationStatus.ps1"
+. "${ScriptDir}\..\..\PSGradient\GradientHelpers\PSInvokeGetServiceIds.ps1"
+. "${ScriptDir}\..\..\PSGradient\GradientHelpers\PSBuildGradientToken.ps1"
+#Add other imports here
+Get-Module

--- a/integrations/SpamTitan/PSInit.ps1
+++ b/integrations/SpamTitan/PSInit.ps1
@@ -1,0 +1,39 @@
+Function InitGradientConnection {
+    Param(
+        [String]
+        $Command
+    )
+    Process {
+        If (“authenticate”, ”sync-accounts”, ”sync-services”, "update-status", "sync-usage" -NotContains $Command) {
+            Throw “$Command is not a valid action! Please use authenticate, sync-accounts, sync-services, update-status, or sync-usage”
+        }
+
+        #Load ENV
+        Get-Content "$ScriptDir\sample.env" | ForEach-Object {
+        $name, $value = $_.split('=')
+        if ([string]::IsNullOrWhiteSpace($name) || $name.Contains('#')) {
+        continue
+        }
+        Set-Item -Path "env:$name" -Value $value
+    }
+
+    #Validate ENV
+    if ([string]::IsNullOrWhiteSpace($Env:VENDOR_API_KEY) -OR [string]::IsNullOrWhiteSpace($Env:PARTNER_API_KEY)) {
+    Throw "Gradient API keys are required in ENV"
+    }
+
+    #Validate ENV
+    if ([string]::IsNullOrWhiteSpace($Env:API_TOKEN) -OR [string]::IsNullOrWhiteSpace($Env:BASE_URL)) {
+    Throw "Vendor API environment variables are required in ENV"
+    }
+
+    #Can add custom ENV validation here
+
+    $GRADIENT_TOKEN = BuildGradientToken $Env:VENDOR_API_KEY $Env:PARTNER_API_KEY
+
+    #Init SDK
+    Set-PSConfiguration 'https://app.usegradient.com' '' '' @{
+    'Gradient-Token' = $GRADIENT_TOKEN
+    }
+}
+}

--- a/integrations/SpamTitan/PSMain.ps1
+++ b/integrations/SpamTitan/PSMain.ps1
@@ -1,0 +1,12 @@
+$ScriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
+Import-Module "${ScriptDir}\PSImports"
+
+InitGradientConnection $args[0]
+#Process Command
+switch($args[0]){
+    'authenticate' {Set-SpamTitanHeaders; break}
+    'sync-accounts' {Invoke-SyncAccounts; break}
+    'sync-services' {Invoke-SyncServices; break}
+    'update-status' {Invoke-UpdateStatus; break}
+    'sync-usage' {Invoke-SyncUsage; break}
+}

--- a/integrations/SpamTitan/PSSyncUsage.ps1
+++ b/integrations/SpamTitan/PSSyncUsage.ps1
@@ -1,0 +1,39 @@
+Function Invoke-SyncUsage {
+    Param() Process {
+        try {
+            $Organizations = Get-SpamTitanDetails
+            $loop = 0
+            $ServiceIds = Invoke-GetServiceIds
+            foreach ($Organization in $Organizations.GetEnumerator()) {
+                Write-Host $Organization.Value.id $Organization.Value.name
+                $Summary = @{}
+
+                $licenseCount = $Organization.Value.maximum
+
+                $Summary["Total Licenses"] = $licenseCount
+
+                foreach ($service in $Summary.GetEnumerator()) {
+                    if ($service.Value -gt 0) {
+                        $body = Initialize-PSCreateBillingRequest $null $Organization.Value.id $service.Value
+                        $body = $body | Select-Object -Property * -ExcludeProperty clientOId
+
+                        Write-Host $body
+                        try {
+                            # Talk to Gradient API to post request
+                            Write-Host $ServiceIds
+                            Write-Host $ServiceIds[$service.Key]
+                            $response = New-PSBilling $ServiceIds[$service.Key] $body
+                        }
+                        catch {
+                            Write-Host "Failed to update unit count for Organization ID: $($Organization.Value.id), SKU: $($ServiceIds[$service.Key]), Unit Counts: $($service.Value). Error message: $($_)" -ForegroundColor Red
+                        }
+                    }
+                }
+                $loop++
+            }
+        } catch {
+            Write-Error $_
+            throw 'An error occurred while syncing usage. Script execution stopped.'
+        }
+    }
+}

--- a/integrations/SpamTitan/sample.env
+++ b/integrations/SpamTitan/sample.env
@@ -1,0 +1,6 @@
+VENDOR_API_KEY=
+PARTNER_API_KEY=
+API_TOKEN=
+BASE_URL=https://<yourdomain>/restapi
+USER=
+USER_PASSWORD=


### PR DESCRIPTION
Sync a summary of licensing information for each domain group using SpamTitan API. Successfully tested and validated syncing the maximum license information for each domain group over the past 30 days. Modify the $DaysBack variable under Get-SpamTitanDetails to sync usage across a different date range.