### PR TITLE
Integration huntress cleansed organizations

### DIFF
--- a/integrations/Huntress Cleansed Organizations/PSCreateAccountsFromVendor.ps1
+++ b/integrations/Huntress Cleansed Organizations/PSCreateAccountsFromVendor.ps1
@@ -1,0 +1,6 @@
+Function Invoke-SyncAccounts {
+    Param() Process {
+        $orgData = Get-OrganizationsReport
+        return Invoke-CreateAccounts $orgData
+    }
+}

--- a/integrations/Huntress Cleansed Organizations/PSCreateServicesFromVendor.ps1
+++ b/integrations/Huntress Cleansed Organizations/PSCreateServicesFromVendor.ps1
@@ -1,0 +1,7 @@
+ Function Invoke-SyncServices {
+    Param(
+    ) Process {
+        $RequiredServices = GetVendorServices
+        return Invoke-CreateServices $RequiredServices "https://meetgradient.com" "phil.flamingo@meetgradient.com"
+    }
+}

--- a/integrations/Huntress Cleansed Organizations/PSCustomIntegrations.ps1
+++ b/integrations/Huntress Cleansed Organizations/PSCustomIntegrations.ps1
@@ -1,0 +1,282 @@
+#Summary
+
+#This script groups organizations in the Huntress management console based on their names and calculates the number of agents, workstations, and servers in each group. It cleans the organization names using regular expressions and extracts the last part of the name before the "m" character, enabling the splitting of agent counts into servers and workstations. This usage can be synchronized into Synthesize to reconcile individual services within your PSA. Note that this functionality only applies if you create organizations in the "servers-m-companyname" and "workstations-m-companyname" format in the Huntress management console.
+#If you don't require the cleansing and grouping of unique organizations in Huntress, please refer to the other Huntress integration available within the Synthesize SDK PS.
+
+$VerbosePreference = 'Continue'
+
+#The code defines a PowerShell function named "Invoke-HuntressAPI" that sends an API request to the Huntress API, handles rate limiting, and returns the JSON response.
+#The function takes several parameters, including the API key and API secret key, and retries failed requests up to a specified maximum number of times.
+
+#Authorization
+function Invoke-HuntressAPI
+{
+    param (
+        [string]$Uri,
+        [string]$Method,
+        [string]$Env:API_KEY,
+        [string]$Env:API_SECRET_KEY,
+        [int]$MaxRetries = 5,
+        [int]$InitialRetryInterval = 2
+    )
+
+    $credentials = "$( $Env:API_KEY ):$Env:API_SECRET_KEY"
+    $base64Credentials = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes($credentials))
+    $headers = @{
+        'Authorization' = "Basic $base64Credentials"
+        'Accept' = 'application/json'
+        'Content-Type' = 'application/json'
+    }
+
+    $retryCount = 0
+    $retryInterval = $InitialRetryInterval
+
+    do
+    {
+        try
+        {
+            Write-Verbose "Sending API request: Method=$Method, Uri=$Uri, Headers=$( $headers | ConvertTo-Json -Depth 2 )"
+            $response = Invoke-WebRequest -Uri $Uri -Method $Method -Headers $headers
+            $jsonResponse = (ConvertFrom-Json -InputObject $response.Content)
+            Write-Verbose "API response: $( $jsonResponse | ConvertTo-Json -Depth 2 )"
+            return $jsonResponse
+        }
+        catch
+        {
+            $responseError = $_.Exception.Response
+            $statusCode = $responseError.StatusCode
+
+            if ($statusCode -eq 429)
+            {
+                # 429 is the HTTP status code for "Too Many Requests"
+                $retryCount++
+                if ($retryCount -le $MaxRetries)
+                {
+                    Write-Warning "API request rate limit reached. Retrying in $retryInterval seconds..."
+                    Start-Sleep -Seconds $retryInterval
+                    $retryInterval *= 2
+                }
+                else
+                {
+                    Write-Error "API request failed due to rate limit. Max retries reached."
+                    break
+                }
+            }
+            else
+            {
+                Write-Error "API request failed: $_"
+                return $null
+            }
+        }
+    } while ($retryCount -le $MaxRetries)
+}
+
+#Get-Organizations: Retrieves a list of organizations from the API endpoint.
+#Get-AgentOrganizationMap: Retrieves a list of agents from the API endpoint and creates a mapping between each agent and its organization.
+#Group-Organizations: Groups the organizations by name and aggregates the number of agents associated with each organization.
+#Get-OrganizationsReport: Calls the previous functions to retrieve and group the data, and then generates a JSON report that includes the name of each organization, the total number of agents associated with it, and the number of workstations and servers.
+
+#Get Organizations
+function Get-Organizations {
+    param ()
+
+    $organizationsApi = "/v1/organizations"
+    $organizationsUrl = $Env:API_URL + $organizationsApi
+
+    $organizations = @()
+    $maxRetries = 5
+    $retryInterval = 2
+    $retryCount = 0
+
+    do {
+        try {
+            $response = Invoke-HuntressAPI -Uri $organizationsUrl -Headers $Headers -Method 'Get'
+            $organizations = $response.organizations
+            $retryCount = $maxRetries + 1
+        } catch {
+            $retryCount++
+            if ($retryCount -le $maxRetries) {
+                Write-Warning "Error fetching organizations: $_. Retrying in $($retryInterval) seconds..."
+                Start-Sleep -Seconds $retryInterval
+                $retryInterval *= 2
+            } else {
+                Write-Error "Error fetching organizations: $_"
+                $organizations = @()
+                break
+            }
+        }
+    } while ($retryCount -le $maxRetries)
+
+    return $organizations
+}
+
+function Get-AgentOrganizationMap
+{
+    param (
+    )
+
+    $agentsApi = "/v1/agents"
+    $agentsUrl = $Env:API_URL + $agentsApi
+
+    $agents = @()
+    $maxRetries = 5
+    $retryInterval = 2
+    $retryCount = 0
+
+    do
+    {
+        try
+        {
+            $response = Invoke-HuntressAPI -Uri $agentsUrl -Headers $Headers -Method 'Get'
+            $agents = $response.agents
+            $retryCount = $maxRetries + 1
+        }
+        catch
+        {
+            $retryCount++
+            if ($retryCount -le $maxRetries)
+            {
+                Write-Warning "Error fetching agents: $_. Retrying in $( $retryInterval ) seconds..."
+                Start-Sleep -Seconds $retryInterval
+                $retryInterval *= 2
+            }
+            else
+            {
+                Write-Error "Error fetching agents: $_"
+                $agents = @()
+                break
+            }
+        }
+    } while ($retryCount -le $maxRetries)
+
+    $agentOrgMap = @{ }
+    foreach ($agent in $agents)
+    {
+        $orgId = $agent.organization_id
+        if (-not $agentOrgMap.ContainsKey($orgId))
+        {
+            $agentOrgMap[$orgId] = @{
+                'total' = 0
+            }
+        }
+        $agentOrgMap[$orgId]['total']++
+    }
+
+    return $agentOrgMap
+}
+
+#The code defines a PowerShell function called "Group-Organizations" that groups a list of organizations based on their names and calculates the number of agents, workstations, and servers in each group.
+#The function uses a regular expression to clean the organization name and extract the last part of the name before the "m" character.
+#The function returns a hashtable that maps group names to their corresponding agent counts, which can be used for reporting or further analysis.
+
+function Group-Organizations {
+    param (
+        [Parameter(Mandatory = $true)]
+        [array]$Organizations,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$AgentOrganizationMap
+    )
+
+    $orgGroupMap = @{ }
+    foreach ($org in $Organizations) {
+        $orgId = $org.id
+        $orgName = $org.name
+
+        if (-not [string]::IsNullOrEmpty($orgName)) {
+            $splitName = $orgName -split '[\.-]'
+            $lastPartIndex = $splitName.Count - 1
+            for ($i = $lastPartIndex; $i -ge 0; $i--) {
+                if ($splitName[$i] -eq "m") {
+                    break
+                }
+            }
+
+            $cleanedNameParts = @()
+            for ($j = $i + 1; $j -le $lastPartIndex; $j++) {
+                $cleanedNameParts += $splitName[$j]
+            }
+            $cleanedName = $cleanedNameParts -join '-'
+        } else {
+            $cleanedName = "Unknown"
+        }
+
+        $agentCounts = @{
+            'Total' = 0
+            'Workstations' = 0
+            'Servers' = 0
+        }
+        if ($AgentOrganizationMap.ContainsKey($orgId)) {
+            $agentCounts = $AgentOrganizationMap[$orgId]
+        }
+
+        if (-not $orgGroupMap.ContainsKey($cleanedName)) {
+            $orgGroupMap[$cleanedName] = @{
+                'Total Agents' = 0
+                'Workstations' = 0
+                'Servers' = 0
+                'id' = 0
+            }
+        }
+
+        $orgGroupMap[$cleanedName]['Total Agents'] += $agentCounts['Total']
+        if ($orgName -match 'servers') {
+            $orgGroupMap[$cleanedName]['Servers'] += $agentCounts['Total']
+        } elseif ($orgName -match 'wkstns' -or $orgName -match 'workstations') {
+            $orgGroupMap[$cleanedName]['Workstations'] += $agentCounts['Total']
+        }
+        $orgGroupMap[$cleanedName]['id'] += $orgId
+    }
+
+    return $orgGroupMap
+}
+
+#The function retrieves a list of organizations from the Huntress management console and generates a report of the number of agents, workstations, and servers in each organization.
+#The function calls the "Group-Organizations" function to group the organizations based on their names and calculate the agent counts, and creates a hashtable called $orgData that maps organization IDs to their corresponding name and agent counts.
+#The function returns the $orgData hashtable containing the report data.
+
+function Get-OrganizationsReport {
+    param ()
+
+    $organizations = Get-Organizations
+    $agentOrgMap = Get-AgentOrganizationMap
+    $orgGroupMap = Group-Organizations -Organizations $organizations -AgentOrganizationMap $agentOrgMap
+
+    $orgData = @{}
+
+    foreach ($org in $orgGroupMap.Keys) {
+        $groupTotalAgents = $orgGroupMap[$org]['Total Agents']
+        $groupWorkstations = $orgGroupMap[$org]['Workstations']
+        $groupServers = $orgGroupMap[$org]['Servers']
+        $groupID = $orgGroupMap[$org]['id']
+
+        $orgUniqueId = $groupID.ToString()
+        $orgName = $org
+
+        $orgData[$orgUniqueId] = @{
+            'id' = $orgUniqueId
+            'name' = $orgName
+            'Total Agents' = $groupTotalAgents
+            'Workstations' = $groupWorkstations
+            'Servers' = $groupServers
+        }
+    }
+
+    return $orgData
+}
+
+#The "GetVendorServices" function creates vendor services in Synthesize that map to services in your PSA.
+#The function returns a list of properties needed to create the services, which includes "Total Agents," "Workstations," and "Servers."
+#These properties are calculated based on the number of agents that had servers or workstations within the organization name, which were grouped and cleansed using the "Group-Organizations" function.
+
+Function GetVendorServices
+{
+    Process {
+        $propertiesToCreateServices = @(
+        @{ Name = "Total Agents"; Description = "Managed EDR"; Category = "security"; Subcategory = "other" },
+        @{ Name = "Workstations"; Description = "Managed EDR"; Category = "security"; Subcategory = "other" },
+        @{ Name = "Servers"; Description = "Managed EDR"; Category = "security"; Subcategory = "other" }
+        )
+        return $propertiesToCreateServices
+    }
+}

--- a/integrations/Huntress Cleansed Organizations/PSImports.psm1
+++ b/integrations/Huntress Cleansed Organizations/PSImports.psm1
@@ -1,0 +1,16 @@
+$ScriptDir = Split-Path $script:MyInvocation.MyCommand.Path
+#
+Import-Module -Name "${ScriptDir}\..\..\PSGradient"
+. "${ScriptDir}\PSInit.ps1"
+. "${ScriptDir}\PSCreateAccountsFromVendor.ps1"
+. "${ScriptDir}\PSCreateServicesFromVendor.ps1"
+. "${ScriptDir}\PSSyncUsage.ps1"
+. "${ScriptDir}\PSCustomIntegrations.ps1"
+. "${ScriptDir}\..\..\PSGradient\GradientHelpers\PSAuthenticate.ps1"
+. "${ScriptDir}\..\..\PSGradient\GradientHelpers\PSCreateAccounts.ps1"
+. "${ScriptDir}\..\..\PSGradient\GradientHelpers\PSCreateServices.ps1"
+. "${ScriptDir}\..\..\PSGradient\GradientHelpers\PSUpdateIntegrationStatus.ps1"
+. "${ScriptDir}\..\..\PSGradient\GradientHelpers\PSInvokeGetServiceIds.ps1"
+. "${ScriptDir}\..\..\PSGradient\GradientHelpers\PSBuildGradientToken.ps1"
+#Add other imports here
+Get-Module

--- a/integrations/Huntress Cleansed Organizations/PSInit.ps1
+++ b/integrations/Huntress Cleansed Organizations/PSInit.ps1
@@ -1,0 +1,39 @@
+Function InitGradientConnection {
+    Param(
+        [String]
+        $Command
+    )
+    Process {
+        If (“authenticate”, ”sync-accounts”, ”sync-services”, "update-status", "sync-usage" -NotContains $Command) {
+            Throw “$Command is not a valid action! Please use authenticate, sync-accounts, sync-services, update-status, or sync-usage”
+        }
+
+        #Load ENV
+        Get-Content "$ScriptDir\.env" | ForEach-Object {
+        $name, $value = $_.split('=')
+        if ([string]::IsNullOrWhiteSpace($name) || $name.Contains('#')) {
+        continue
+        }
+        Set-Item -Path "env:$name" -Value $value
+    }
+
+    #Validate ENV
+    if ([string]::IsNullOrWhiteSpace($Env:VENDOR_API_KEY) -OR [string]::IsNullOrWhiteSpace($Env:PARTNER_API_KEY)) {
+    Throw "Gradient API keys are required in ENV"
+    }
+
+    #Validate ENV
+    if ([string]::IsNullOrWhiteSpace($Env:API_KEY) -OR [string]::IsNullOrWhiteSpace($Env:API_SECRET_KEY) -OR [string]::IsNullOrWhiteSpace($Env:API_URL)) {
+    Throw "Vendor API environment variables are required in ENV"
+    }
+
+    #Can add custom ENV validation here
+
+    $GRADIENT_TOKEN = BuildGradientToken $Env:VENDOR_API_KEY $Env:PARTNER_API_KEY
+
+    #Init SDK
+    Set-PSConfiguration 'https://app.usegradient.com' '' '' @{
+    'Gradient-Token' = $GRADIENT_TOKEN
+    }
+}
+}

--- a/integrations/Huntress Cleansed Organizations/PSMain.ps1
+++ b/integrations/Huntress Cleansed Organizations/PSMain.ps1
@@ -1,0 +1,12 @@
+$ScriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
+Import-Module "${ScriptDir}\PSImports"
+
+InitGradientConnection $args[0]
+#Process Command
+switch($args[0]){
+    'authenticate' {Invoke-HuntressAPI; break}
+    'sync-accounts' {Invoke-SyncAccounts; break}
+    'sync-services' {Invoke-SyncServices; break}
+    'update-status' {Invoke-UpdateStatus; break}
+    'sync-usage' {Invoke-SyncUsage; break}
+}

--- a/integrations/Huntress Cleansed Organizations/PSSyncUsage.ps1
+++ b/integrations/Huntress Cleansed Organizations/PSSyncUsage.ps1
@@ -1,0 +1,50 @@
+#The function retrieves a report of organizations and their corresponding agent counts using the "Get-OrganizationsReport" function.
+#It retrieves a list of service IDs from the Synthesize platform using the "Invoke-GetServiceIds" function.
+#For each organization in the report, the function calculates the total number of agents, workstations, and servers using the data from the report.
+#It creates a billing request for each service type that has a count greater than zero and sends the request to the Synthesize API using the "New-PSBilling" function.
+
+Function Invoke-SyncUsage {
+    Param()
+
+    Process {
+        try {
+            $OrgData = Get-OrganizationsReport
+            $loop = 0
+            $ServiceIds = Invoke-GetServiceIds
+
+            foreach ($orgUniqueId in $OrgData.Keys) {
+                $Organization = $OrgData[$orgUniqueId]
+
+                Write-Host $Organization.id $Organization.name
+
+                $Summary = @{
+                    'Total Agents'  = $Organization.'Total Agents'
+                    'Workstations'  = $Organization.Workstations
+                    'Servers'       = $Organization.Servers
+                }
+
+                foreach ($service in $Summary.GetEnumerator()) {
+                    if ($service.Value -gt 0) {
+                        $body = Initialize-PSCreateBillingRequest $null $Organization.id $service.Value
+                        $body = $body | Select-Object -Property * -ExcludeProperty clientOId
+
+                        Write-Host $body
+
+                        try {
+                            # Talk to Gradient API to post request
+                            Write-Host $ServiceIds
+                            Write-Host $ServiceIds[$service.Key]
+                            $response = New-PSBilling $ServiceIds[$service.Key] $body
+                        } catch {
+                            Write-Host "Failed to update unit count for Organization ID: $($Organization.id), SKU: $($ServiceIds[$service.Key]), Unit Counts: $($service.Value). Error message: $($_)" -ForegroundColor Red
+                        }
+                    }
+                }
+                $loop++
+            }
+        } catch {
+            Write-Error $_
+            throw 'An error occurred while syncing usage. Script execution stopped.'
+        }
+    }
+}

--- a/integrations/Huntress Cleansed Organizations/sample.env
+++ b/integrations/Huntress Cleansed Organizations/sample.env
@@ -1,0 +1,5 @@
+VENDOR_API_KEY=
+PARTNER_API_KEY=
+API_KEY=
+API_SECRET_KEY=
+API_URL=https://api.huntress.io

--- a/integrations/NinjaOne/PSCreateAccountsFromVendor.ps1
+++ b/integrations/NinjaOne/PSCreateAccountsFromVendor.ps1
@@ -1,0 +1,7 @@
+Function Invoke-SyncAccounts {
+    Param() Process {
+        $Organizations = Get-Organizations
+        return Invoke-CreateAccounts $Organizations
+    }
+}
+

--- a/integrations/NinjaOne/PSCreateServicesFromVendor.ps1
+++ b/integrations/NinjaOne/PSCreateServicesFromVendor.ps1
@@ -1,0 +1,7 @@
+ Function Invoke-SyncServices {
+    Param(
+    ) Process {
+        $RequiredServices = GetVendorServices
+        return Invoke-CreateServices $RequiredServices "https://meetgradient.com" "phil.flamingo@meetgradient.com"
+    }
+}

--- a/integrations/NinjaOne/PSCustomIntegrations.ps1
+++ b/integrations/NinjaOne/PSCustomIntegrations.ps1
@@ -1,0 +1,193 @@
+#The Invoke-NinjaOne function is used to obtain an authentication header for a NinjaRMM API.
+#The function constructs an authentication request body, sends it to the API endpoint using Invoke-WebRequest, extracts the access token from the response content, and constructs an authentication header with the access token.
+
+function Invoke-NinjaOne
+{
+    param (
+    )
+
+    try
+    {
+        $AuthBody = @{
+            'grant_type' = 'client_credentials'
+            'client_id' = $Env:API_KEY
+            'client_secret' = $Env:API_SECRET_KEY
+            'scope' = 'monitoring'
+        }
+
+        $Result = Invoke-WebRequest -uri "$( $Env:API_URL )/ws/oauth/token" -Method POST -Body $AuthBody -ContentType 'application/x-www-form-urlencoded'
+
+        $AuthHeader = @{
+            'Authorization' = "Bearer $( ($Result.content | ConvertFrom-Json).access_token )"
+        }
+
+        return $AuthHeader
+    }
+    catch
+    {
+        Write-Host "Error: $( $_.Exception.Message )"
+        return $null
+    }
+}
+
+#The function implements an exponential backoff algorithm for making API requests with retry logic, with a configurable maximum number of retries and initial delay time.
+#The Invoke-NinjaOne function is used to obtain an authentication header before making the API request using Invoke-WebRequest.
+
+function Invoke-ExponentialBackoff
+{
+    param (
+        [Parameter(Mandatory = $true)][string] $Uri,
+        [Parameter(Mandatory = $true)][string] $Method,
+        [hashtable] $Headers,
+        [int] $MaxRetries = 5,
+        [int] $InitialDelaySeconds = 2,
+        [bool] $AuthRequired = $false
+    )
+
+    $RetryCount = 0
+    $DelaySeconds = $InitialDelaySeconds
+
+    if ($AuthRequired)
+    {
+        $Headers = Invoke-NinjaOne
+    }
+
+    while ($RetryCount -lt $MaxRetries)
+    {
+        try
+        {
+            $Response = Invoke-WebRequest -uri $Uri -Method $Method -Headers $Headers -ErrorAction Stop
+            return $Response
+        }
+        catch
+        {
+            $StatusCode = $_.Exception.Response.StatusCode.value__
+            if ($StatusCode -eq 429 -or ($StatusCode -ge 500 -and $StatusCode -le 599))
+            {
+                Write-Host "Request failed with status code $StatusCode. Retrying in $( $DelaySeconds ) seconds..."
+                Start-Sleep -Seconds $DelaySeconds
+                $RetryCount++
+                $DelaySeconds = $DelaySeconds * 2
+            }
+            else
+            {
+                throw $_
+            }
+        }
+    }
+
+    throw "Failed to make request after $( $MaxRetries ) retries"
+}
+
+#The function retrieves a list of vendor accounts (organizations) from a NinjaOne API endpoint, using Invoke-ExponentialBackoff to implement an exponential backoff algorithm for making the API request with retry logic.
+#The function constructs a hashtable that maps organization IDs to their respective names, and returns this hashtable. If an error occurs during execution of the function, the error message is written out and the script execution is stopped.
+
+function Get-Organizations
+{
+    param (
+    )
+
+    try
+    {
+        $PageSize = 100
+        $After = 0
+        $Headers = Invoke-NinjaOne
+
+        if ($null -eq $Headers)
+        {
+            throw 'Headers are null'
+        }
+
+        $Uri = "$( $Env:API_URL )/v2/organizations?pageSize=$PageSize&after=$After"
+        $Response = Invoke-ExponentialBackoff -Uri $Uri -Method GET -Headers $Headers | ConvertFrom-Json
+
+        if ($null -eq $Response)
+        {
+            throw 'Response is null'
+        }
+
+        $Organizations = @{ }
+        foreach ($Organization in $Response)
+        {
+            $id = $Organization.id
+            $name = $Organization.name
+            $OrganizationData = @{
+                "id" = $id
+                "name" = $name
+            }
+            $Organizations[$id] = $OrganizationData
+        }
+
+        return $Organizations
+    }
+    catch
+    {
+        Write-Error $_
+        throw 'An error occurred while getting organizations. Script execution stopped.'
+    }
+}
+
+#The function retrieves a list of devices from a NinjaOne API endpoint, using Invoke-ExponentialBackoff to implement an exponential backoff algorithm for making the API request with retry logic.
+#The function constructs an array of device data for each device in the response, including the device ID, parent device ID, organization ID, location ID, node class, and offline status, and returns this array. If an error occurs during execution of the function, the error message is written out and $null is returned.
+
+function Get-Devices
+{
+    param (
+        [int] $PageSize = 100,
+        [int] $After = 0,
+        [bool] $Offline = $false
+    )
+
+    try
+    {
+        $Devices = @()
+        $Response = $null
+        $Headers = Invoke-NinjaOne
+
+        do
+        {
+            $Uri = "$( $Env:API_URL )/v2/devices?pageSize=$PageSize&after=$After&offline=$Offline"
+            $Response = Invoke-ExponentialBackoff -Uri $Uri -Method GET -Headers $Headers | ConvertFrom-Json
+
+            foreach ($Device in $Response)
+            {
+                $DeviceData = @{
+                    "id" = $Device.id
+                    "parentDeviceId" = $Device.parentDeviceId
+                    "organizationId" = $Device.organizationId
+                    "locationId" = $Device.locationId
+                    "nodeClass" = $Device.nodeClass
+                    "offline" = $Device.offline
+                }
+                $Devices += $DeviceData
+            }
+
+            $After = $Response[-1].id
+        } while ($Response.Count -eq $PageSize)
+
+        return $Devices
+    }
+    catch
+    {
+        Write-Host "Error: $( $_.Exception.Message )"
+        return $null
+    }
+}
+
+#The function returns an array of hashtables, with each hashtable containing information about a service offered by a vendor, including the service name, description, category, and subcategory.
+#The services included in the array are related to security and other device types, such as workstations, servers, and network devices.
+#If you need to modify the name of an existing service or add new services, you can do so here. After modifying the services, make sure to create the respective counts in the Invoke-SyncUsage function.
+
+Function GetVendorServices
+{
+    Process {
+        $propertiesToCreateServices = @(
+        @{ Name = "Total Devices"; Description = "Total Devices"; Category = "security"; Subcategory = "other" },
+        @{ Name = "Total Servers"; Description = "Total Servers"; Category = "security"; Subcategory = "other" },
+        @{ Name = "Total Workstations"; Description = "Total Workstations"; Category = "security"; Subcategory = "other" },
+        @{ Name = "Total Network Devices"; Description = "Total Network Devices"; Category = "security"; Subcategory = "other" },
+        @{ Name = "Total Virtual Machines"; Description = "Total Virtual Machines"; Category = "security"; Subcategory = "other" }
+        )
+        return $propertiesToCreateServices
+    }
+}

--- a/integrations/NinjaOne/PSImports.psm1
+++ b/integrations/NinjaOne/PSImports.psm1
@@ -1,0 +1,16 @@
+$ScriptDir = Split-Path $script:MyInvocation.MyCommand.Path
+#
+Import-Module -Name "${ScriptDir}\..\..\PSGradient"
+. "${ScriptDir}\PSInit.ps1"
+. "${ScriptDir}\PSCreateAccountsFromVendor.ps1"
+. "${ScriptDir}\PSCreateServicesFromVendor.ps1"
+. "${ScriptDir}\PSSyncUsage.ps1"
+. "${ScriptDir}\PSCustomIntegrations.ps1"
+. "${ScriptDir}\..\..\PSGradient\GradientHelpers\PSAuthenticate.ps1"
+. "${ScriptDir}\..\..\PSGradient\GradientHelpers\PSCreateAccounts.ps1"
+. "${ScriptDir}\..\..\PSGradient\GradientHelpers\PSCreateServices.ps1"
+. "${ScriptDir}\..\..\PSGradient\GradientHelpers\PSUpdateIntegrationStatus.ps1"
+. "${ScriptDir}\..\..\PSGradient\GradientHelpers\PSInvokeGetServiceIds.ps1"
+. "${ScriptDir}\..\..\PSGradient\GradientHelpers\PSBuildGradientToken.ps1"
+#Add other imports here
+Get-Module

--- a/integrations/NinjaOne/PSInit.ps1
+++ b/integrations/NinjaOne/PSInit.ps1
@@ -1,0 +1,39 @@
+Function InitGradientConnection {
+    Param(
+        [String]
+        $Command
+    ) Process {
+
+        If (“authenticate”, ”sync-accounts”, ”sync-services”, "update-status", "sync-usage" -NotContains $Command) {
+            Throw “$Command is not a valid action! Please use authenticate, sync-accounts, sync-services, update-status, or sync-usage”
+        }
+
+        #Load ENV
+        Get-Content "$ScriptDir\.env" | foreach {
+        $name, $value = $_.split('=')
+        if ([string]::IsNullOrWhiteSpace($name) || $name.Contains('#')) {
+            continue
+        }
+        Set-Item -Path "env:$name" -Value $value
+    }
+
+        #Validate ENV
+        If ([string]::IsNullOrWhiteSpace($Env:VENDOR_API_KEY) -OR [string]::IsNullOrWhiteSpace($Env:PARTNER_API_KEY) ) {
+            Throw "Gradient API keys are required in ENV"
+        }
+
+        #Validate ENV
+        If ([string]::IsNullOrWhiteSpace($Env:API_URL) -OR [string]::IsNullOrWhiteSpace($Env:API_KEY) -OR [string]::IsNullOrWhiteSpace($Env:API_SECRET_KEY) ) {
+            Throw "NinjaOne API keys are required in ENV"
+        }
+
+        #Can add custom ENV validation here
+
+        $GRADIENT_TOKEN = BuildGradientToken $Env:VENDOR_API_KEY $Env:PARTNER_API_KEY
+
+        #Init SDK
+        Set-PSConfiguration 'https://app.usegradient.com' '' '' @{
+            'Gradient-Token' = $GRADIENT_TOKEN
+        }
+    }
+}

--- a/integrations/NinjaOne/PSMain.ps1
+++ b/integrations/NinjaOne/PSMain.ps1
@@ -1,0 +1,12 @@
+$ScriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
+Import-Module "${ScriptDir}\PSImports"
+
+InitGradientConnection $args[0]
+#Process Command
+switch($args[0]){
+    'authenticate' {Invoke-NinjaOne; break}
+    'sync-accounts' {Invoke-SyncAccounts; break}
+    'sync-services' {Invoke-SyncServices; break}
+    'update-status' {Invoke-UpdateStatus; break}
+    'sync-usage' {Invoke-SyncUsage; break}
+}

--- a/integrations/NinjaOne/PSSyncUsage.ps1
+++ b/integrations/NinjaOne/PSSyncUsage.ps1
@@ -1,0 +1,59 @@
+#The function aggregates device counts based on their node class for each vendor account, creates a billing request for each non-zero service count, and sends the request to the Synthesize API.
+#To add or modify a service, you will need to modify the services array returned by GetVendorServices. Note that this function aggregates device counts based on NodeClass. For a full list of Node Roles, please refer to the documentation at the following URL: https://app.ninjarmm.com/apidocs-beta/core-resources/operations/getNodeRoles.
+
+Function Invoke-SyncUsage {
+    Param(
+    ) Process {
+        try {
+            Write-Host "Starting call"
+            $deviceSummary = @()
+            $VendorAccounts =  Get-Organizations
+            $loop = 0
+            $ServiceIds = Invoke-GetServiceIds
+            $Devices = Get-Devices
+            foreach ($site in $VendorAccounts.GetEnumerator()) {
+                Write-Host $site.Value.id $site.Value.name
+                $Summary = @{}
+                $loop++
+                #Get Active Licenses
+                $siteDevices = $Devices | Where-Object { $_.organizationId -eq $site.Value.id -and $_.offline -eq $false }
+                $totalWorkstations = ($siteDevices | Where-Object { $_.offline -eq $false -and $_.nodeClass -match 'Workstation|Computer|MAC' }).count
+                $serverCount = ($siteDevices | Where-Object { $_.offline -eq $false -and $_.nodeClass -match 'Server|VM|VMM|NMS_VIRTUAL_MACHINE' }).count
+                $networkDeviceCount = ($siteDevices | Where-Object { $_.offline -eq $false -and $_.nodeClass -match 'NMS_FIREWALL|NMS_ROUTER|NMS_SWITCH|NMS_WAP' }).count
+                $totalDevices = $totalWorkstations + $serverCount + $networkDeviceCount
+
+                Write-Host 'Setting Summary'
+                $Summary['Total Devices'] = $totalDevices
+                $Summary['Total Servers'] = $serverCount
+                $Summary['Total Workstations'] = $totalWorkstations
+                $Summary['Total Network Devices'] = $networkDeviceCount
+                Write-Host 'Loop through summary'
+                foreach ($service in $Summary.GetEnumerator()) {
+                    if($service.Value -gt 0)
+                    {
+                        $body = Initialize-PSCreateBillingRequest  $null $site.Value.id $service.Value
+                        $body = $body | Select-Object -Property * -ExcludeProperty clientOId
+
+                        Write-Host $body
+                        try
+                        {
+                            #Talk to Gradient API to post request
+                            Write-Host 'Sending for client'
+                            Write-Host $ServiceIds
+                            Write-Host $ServiceIds[$Service.Key]
+                            $response = New-PSBilling $ServiceIds[$Service.Key] $body
+                        }
+                        catch
+                        {
+                            Write-Host "Failed to update unit count for Site ID: $( $site.Value.id ), SKU: $( $ServiceIds[$Service.Key] ), Unit Counts: $( $service.Value ). Error message: $( $_ )" -ForegroundColor Red
+                        }
+                    }
+                }
+            }
+            Write-Host $deviceSummary
+        } catch {
+            Write-Error $_
+            throw 'An error occurred while syncing usage. Script execution stopped.'
+        }
+    }
+}

--- a/integrations/NinjaOne/sample.env
+++ b/integrations/NinjaOne/sample.env
@@ -1,0 +1,9 @@
+#Vendor and Partner API Keys are generated in Synthesize when creating a custom integration. It is used to generate a Base64 encrypted GRADIENT-TOKEN to call Synthesize API endpoints. To obtain this key, you will need to create a custom integration in Synthesize and generate an API key for that integration.
+VENDOR_API_KEY=
+PARTNER_API_KEY=
+# This is the API URL required to call NinjaOne API endpoints.
+API_URL=https://api.ninjarmm.com
+# This is an API key that is used to authenticate with the NinjaOne API. To obtain an API key, you will need to create a new API user in the NinjaOne web interface and generate an API key for that client.
+API_KEY=
+#This is the secret key that corresponds to the API key used for authentication with the NinjaOne API. To obtain this key, you will need to generate it when you create the API user in the NinjaOne web interface.
+API_SECRET_KEY=


### PR DESCRIPTION
This script retrieves the number of workstation and server agents from organizations in the Huntress Management Console that follow the naming conventions of 'server-m-companyname' and 'workstation-m-companyname'. This is a unique way to sync agent counts across servers and workstations, which is useful if you want to separate these services in your PSA.